### PR TITLE
增加Docker支持以便于部署

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,174 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Data and model directories
+/data/
+/experiments/
+/pretrained/
+*.mid
+*.wav
+
+# git
+.git
+.github
+.gitignore
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM busybox as downloader
+WORKDIR /home
+RUN wget -O- https://github.moeyy.xyz/https://github.com/openvpi/SOME/releases/latest/download/0918_continuous256_clean_3spk_fixmel.zip|unzip -
+FROM pytorch/pytorch:2.1.0-cuda11.8-cudnn8-devel
+COPY . /opt/app
+WORKDIR /opt/app
+RUN pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt gradio==3.47.1
+COPY --from=downloader /home experiments
+EXPOSE 7860
+CMD [ "python", "webui.py","--addr=0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /opt/app
 RUN pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt gradio==3.47.1
 COPY --from=downloader /home experiments
 EXPOSE 7860
-CMD [ "python", "webui.py","--addr=0.0.0.0" ]
+CMD [ "python", "webui.py", "--addr=0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM busybox as downloader
 WORKDIR /home
-RUN wget -O- https://github.moeyy.xyz/https://github.com/openvpi/SOME/releases/latest/download/0918_continuous256_clean_3spk_fixmel.zip|unzip -
+LABEL org.opencontainers.image.source=https://github.com/openvpi/SOME
+LABEL org.opencontainers.image.description="SOME: Singing-Oriented MIDI Extractor."
+LABEL org.opencontainers.image.licenses=MIT
+RUN wget -O- https://github.com/openvpi/SOME/releases/latest/download/0918_continuous256_clean_3spk_fixmel.zip|unzip -
 FROM pytorch/pytorch:2.1.0-cuda11.8-cudnn8-devel
 COPY . /opt/app
 WORKDIR /opt/app
-RUN pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt gradio==3.47.1
+RUN pip3 install -r requirements.txt gradio==3.47.1
 COPY --from=downloader /home experiments
 EXPOSE 7860
 CMD [ "python", "webui.py", "--addr=0.0.0.0" ]

--- a/webui.py
+++ b/webui.py
@@ -67,8 +67,9 @@ def infer(model_rel_path, input_audio_path, tempo_value):
 
 @click.command(help='Launch the web UI for inference')
 @click.option('--port', type=int, default=7860, help='Server port')
+@click.option('--addr', type=str, required=False, help='Server address')
 @click.option('--work_dir', type=str, required=False, help='Directory to read the experiments')
-def webui(port, work_dir):
+def webui(port, work_dir, addr):
     if work_dir is None:
         work_dir = pathlib.Path(__file__).with_name('experiments')
     else:
@@ -101,7 +102,7 @@ def webui(port, work_dir):
         ]
     )
     iface.queue(concurrency_count=10)
-    iface.launch(server_port=port)
+    iface.launch(server_port=port, server_name=addr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
有[Docker](https://www.docker.com/)支持的情况下部署只需两条命令（需要提前[安装Docker](https://docs.docker.com/get-docker/)，[Docker](https://docs.docker.com/engine/install/)、[Docker Desktop](https://docs.docker.com/desktop/)都可以）
> 理论上Windows 7配[Docker Toolbox](https://github.com/docker-archive/toolbox)也可以
> NVIDIA显卡用户需要配置[NVIDIA Container Toolkit(nvidia-docker)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/index.html)才能启用GPU加速(Windows 11也支持)

```bash
docker build -t openvpi/some https://github.com/openvpi/SOME.git
docker run -it --rm -p 7860:7860 --gpus all openvpi/some
```

如果不想用GPU，删除--gpus all即可

注：
1. Docker需要服务支持监听在0.0.0.0上，我已添加相关补丁
2. 默认使用gradio 3.47.1，因为最新版gradio改了一堆东西
3. 默认使用NVIDIA版的pytorch，需要兼容其他平台只需把FROM pytorch/pytorch:2.1.0-cuda11.8-cudnn8-devel改掉就行